### PR TITLE
Fix Import Error

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,5 +1,5 @@
 const fetch = require('node-fetch')
-const https = require('node:https')
+const https = require('https')
 
 exports.sourceNodes = async (
   { actions, ...createNodeHelperFunctions },


### PR DESCRIPTION
# Summary

Fix node import of 'https'

# Description

The 'https' import was incorrect. Update the `require` statement to pull the appropriate node module.